### PR TITLE
Add diff calculate function

### DIFF
--- a/autoload/spaceline/utils.vim
+++ b/autoload/spaceline/utils.vim
@@ -7,4 +7,38 @@ function! spaceline#utils#line_is_plain() abort
   return &buftype ==? 'terminal' || &filetype =~? '\v^help|denite|dbui|defx|coc-explorer|vim-plug|nerdtree|vista_kind|vista|magit|tagbar$'
 endfunction
 
+function! spaceline#utils#group_at(f, list, borders) abort
+  " for the first element this must be true to initialise the list with an
+  " empty group at the beginning (if it's not a border that should be
+  " excluded)
+  let l:is_previous_border = v:true
+  let l:grouped_list = []
 
+  for el in a:list
+    " element matches but not borders should be included
+    let l:skip_this = a:f(el) && !a:borders
+
+    if l:is_previous_border && !l:skip_this
+      call add(l:grouped_list, [])
+    endif
+
+    let l:is_previous_border = a:f(el) ? v:true : v:false
+
+    if l:skip_this
+      continue
+    endif
+
+    call add(l:grouped_list[len(l:grouped_list)-1], el)
+  endfor
+
+  return l:grouped_list
+endfunction
+
+function! spaceline#utils#is_inside_work_tree(buffer) abort "{{{1
+  call system('cd ' . expand('#' . a:buffer . ':p:h:S') . ' && git rev-parse --is-inside-work-tree --prefix ' . expand('#' . a:buffer . ':h:S'))
+  return !v:shell_error
+endfunction
+
+function! spaceline#utils#is_git_exectuable() abort "{{{1
+  return executable('git')
+endfunction

--- a/autoload/spaceline/vcs.vim
+++ b/autoload/spaceline/vcs.vim
@@ -6,11 +6,18 @@
 " =============================================================================
 "
 function! spaceline#vcs#git_branch()
-  let l:gitbranch = get(g:, 'coc_git_status', '')
+  let l:gitbranch = ''
+  if g:spaceline_git ==? 'coc'
+    let l:gitbranch = get(g:, 'coc_git_status', '')
+  elseif g:spaceline_git ==? 'default'
+    let l:gitbranch = system(join([ 'git rev-parse --abbrev-ref HEAD 2> /dev/null',
+                          \ 'sed ','tr "\n" " "']
+                    \ , '|'))
+  endif
   if empty(l:gitbranch)
     return ""
   endif
-  if exists('l:git_branch_icon')
+  if exists('g:spaceline_git_branch_icon')
     return l:git_branch_icon . l:gitbranch
   endif
   return l:gitbranch

--- a/autoload/spaceline/vcs.vim
+++ b/autoload/spaceline/vcs.vim
@@ -6,18 +6,7 @@
 " =============================================================================
 "
 function! spaceline#vcs#git_branch()
-  if g:spaceline_git == 'coc'
-    let l:gitbranch = get(g:, 'coc_git_status', '')
-  else
-    let l:git_branch_icon = exists('g:spaceline_git_branch_icon') ? g:spaceline_git_branch_icon : ''
-    if &modifiable
-      let l:dir=expand('%:p:h')
-      let l:gitrevparse = system("git -C ".l:dir." rev-parse --abbrev-ref HEAD")
-      if !v:shell_error
-        let l:gitbranch="(".substitute(l:gitrevparse, '', '', 'g').") "
-      endif
-    endif
-  endif
+  let l:gitbranch = get(g:, 'coc_git_status', '')
   if empty(l:gitbranch)
     return ""
   endif
@@ -28,22 +17,27 @@ function! spaceline#vcs#git_branch()
 endfunction
 
 function! s:add_diff_icon(type) abort
-  let difficon = get(['','',''],a:type,'')
-  let diffdata = split(get(b:, 'coc_git_status', ''),' ')
-  let diff_flags = ''
-  if a:type == 0
-    let diff_flags = '+'
-  elseif a:type == 1
-    let diff_flags = '-'
-  elseif a:type == 2
-    let diff_flags = '\~'
+  let l:difficon = get(['','',''],a:type,'')
+  let l:diffdata=[]
+  if g:spaceline_git ==? 'coc'
+    let l:diffdata = split(get(b:, 'coc_git_status', ''),' ')
+  elseif g:spaceline_git ==? 'default'
+    let l:diffdata = spaceline#vcs#diff_calculate(bufnr('%'))
   endif
-  for item in diffdata
-    if matchend(item,diff_flags) > 0
+  let l:diff_flags = ''
+  if a:type == 0
+    let l:diff_flags = '+'
+  elseif a:type == 1
+    let l:diff_flags = '-'
+  elseif a:type == 2
+    let l:diff_flags = '\~'
+  endif
+  for item in l:diffdata
+    if matchend(item,l:diff_flags) > 0
         if g:symbol == 1
           return item
         else
-          return substitute(item, diff_flags, difficon, '').' '
+          return substitute(item, l:diff_flags, l:difficon, '').' '
         endif
     endif
   endfor
@@ -59,4 +53,81 @@ endfunction
 
 function! spaceline#vcs#diff_modified() abort
   return s:add_diff_icon(2)
+endfunction
+
+" reference
+" https://github.com/niklaas/lightline-gitdiff/blob/master/autoload/lightline/gitdiff/algorithms/word_diff_porcelain.vim
+function! spaceline#vcs#diff_calculate(buffer) abort
+  if !spaceline#utils#is_git_exectuable() || !spaceline#utils#is_inside_work_tree(a:buffer)
+    " b/c there is nothing that can be done here; the algorithm needs git
+    return []
+  endif
+
+  let l:indicator_groups = s:transcode_diff_porcelain(s:get_diff_porcelain(a:buffer))
+
+  let l:changes = map(copy(l:indicator_groups), { idx, val ->
+        \ s:parse_indicator_group(val) })
+
+  let l:lines_added = len(filter(copy(l:changes), { idx, val -> val ==# 'A' }))
+  let l:lines_deleted = len(filter(copy(l:changes), { idx, val -> val ==# 'D' }))
+  let l:lines_modified = len(filter(copy(l:changes), { idx, val -> val ==# 'M' }))
+
+  let l:diff_status=[]
+  if l:lines_added > 0
+    call add(l:diff_status, "+".l:lines_added)
+  endif
+  if l:lines_deleted > 0
+    call add(l:diff_status, "-".l:lines_deleted)
+  endif
+  if l:lines_modified > 0
+    call add(l:diff_status, "~".l:lines_modified)
+  endif
+
+  return l:diff_status
+endfunction
+
+function! s:get_diff_porcelain(buffer) abort
+  let l:porcelain = systemlist('cd ' . expand('#' . a:buffer . ':p:h:S') .
+        \ ' && git diff --no-ext-diff --word-diff=porcelain --unified=0 -- ' . expand('#' . a:buffer . ':t:S'))
+  return l:porcelain[4:]
+endfunction
+
+function! s:transcode_diff_porcelain(porcelain) abort
+  " b/c we do not need the line identifiers
+  call filter(a:porcelain, { idx, val -> val !~# '^@@' })
+
+  " b/c we only need the identifiers at the first char of each diff line
+  call map(a:porcelain, { idx, val -> strcharpart(val, -1, 2) })
+
+  return spaceline#utils#group_at({ el -> el ==# '~' }, a:porcelain, v:true)
+endfunction
+
+function! s:parse_indicator_group(indicators) abort
+  let l:changer = ''
+
+  if len(a:indicators) ==# 1 && a:indicators[0] ==# '~'
+    return 'A'
+  endif
+
+  for el in a:indicators
+    if l:changer ==# '' && ( el ==# '-' || el ==# '+' )
+      let l:changer = el
+      continue
+    endif
+
+    if l:changer ==# '+' && el ==# '~'
+      return 'A'
+    endif
+
+    if l:changer ==# '-' && el ==# '~'
+      return 'D'
+    endif
+
+    if l:changer !=# el
+      return 'M'
+    endif
+  endfor
+
+  " b/c we should never end up here
+  echoerr 'spaceline#vcs: Error parsing indicator group: [ ' . join(a:indicators, ', ') . ' ]'
 endfunction

--- a/autoload/spaceline/vcs.vim
+++ b/autoload/spaceline/vcs.vim
@@ -11,8 +11,7 @@ function! spaceline#vcs#git_branch()
     let l:gitbranch = get(g:, 'coc_git_status', '')
   elseif g:spaceline_git ==? 'default'
     let l:gitbranch = system(join([ 'git rev-parse --abbrev-ref HEAD 2> /dev/null',
-                          \ 'sed ','tr "\n" " "']
-                    \ , '|'))
+                          \ 'sed ','tr "\n" " "'], '|'))
   endif
   if empty(l:gitbranch)
     return ""


### PR DESCRIPTION
Fix #30  This feature will add new support for diff instead of relying on coc-git. You can choose to use coc-git or use the diff calculation provided by spaceline.But I don't know why vim crashes with the new calculation method.