### PR TITLE
Revert emptySeperate1 for Nord theme

### DIFF
--- a/autoload/spaceline/colorscheme/nord.vim
+++ b/autoload/spaceline/colorscheme/nord.vim
@@ -106,5 +106,5 @@ function! spaceline#colorscheme#nord#nord()
   call spaceline#colors#spaceline_hl('StatusFileFormat',s:slc,  'black',  'cyan')
   call spaceline#colors#spaceline_hl('StatusLineinfo',s:slc,  'white',  'gray')
   call spaceline#colors#spaceline_hl('EndSeperate',s:slc,  'purple',  'cyan')
-  call spaceline#colors#spaceline_hl('emptySeperate1',s:slc,  'cyan',  'darknavy')
+  call spaceline#colors#spaceline_hl('emptySeperate1',s:slc,  'gray',  'darknavy')
 endfunction


### PR DESCRIPTION
See https://github.com/glepnir/spaceline.vim/issues/63#issuecomment-766488708 for the reason.
This will fix the 2nd problem but bring back the 1st one in #63. The point is to keep all the themes unified and consistent.

Current behavior:
**Nord**
![nord](https://user-images.githubusercontent.com/67634026/106221584-f24a5300-61ee-11eb-9cbf-026dd787c97b.png)
**Dracula**
![dracula](https://user-images.githubusercontent.com/67634026/106221608-feceab80-61ee-11eb-83c9-0ae2b0ffdcbe.png)
**Space**
![space](https://user-images.githubusercontent.com/67634026/106221624-08581380-61ef-11eb-93ae-fa51d67ec5ed.png)
