### PR TITLE
Fix deprecation error

### DIFF
--- a/autoload/spaceline/diagnostic.vim
+++ b/autoload/spaceline/diagnostic.vim
@@ -61,10 +61,10 @@ endfunction
 
 function! s:diagnostic_nvim_lsp_error()
   if luaeval('#vim.lsp.buf_get_clients(0) ~= 0')
-    if luaeval("vim.lsp.util.buf_diagnostics_count(\"Error\")") == v:null
+    if luaeval("vim.lsp.diagnostic.get_count(\"Error\")") == v:null
       return ''
     else
-      return g:spaceline_errorsign. luaeval("vim.lsp.util.buf_diagnostics_count(\"Error\")")
+      return g:spaceline_errorsign. luaeval("vim.lsp.diagnostic.get_count(\"Error\")")
     end
   else
     return ''
@@ -73,10 +73,10 @@ endfunction
 
 function! s:diagnostic_nvim_lsp_warn()
   if luaeval('#vim.lsp.buf_get_clients(0) ~= 0')
-    if luaeval("vim.lsp.util.buf_diagnostics_count(\"Warning\")") == v:null
+    if luaeval("vim.lsp.diagnostic.get_count(\"Warning\")") == v:null
       return ''
     else
-      return g:spaceline_warnsign. luaeval("vim.lsp.util.buf_diagnostics_count(\"Warning\")")
+      return g:spaceline_warnsign. luaeval("vim.lsp.diagnostic.get_count(\"Warning\")")
     end
   else
     return ''


### PR DESCRIPTION
Fix deprecation error when using nvim_lsp as diagnostic tool engine.

```
Error detected while processing function spaceline#spacelinetoggle[2]..<SNR>63_SetStatusline[6]..<SNR>63_ActiveStatusLine[19]..s
paceline#diagnostic#diagnostic_error[1]..<SNR>67_diagnostic_nvim_lsp_error:
line    2:
buf_diagnostics_count is deprecated. Use 'vim.lsp.diagnostic.get_count'
```