### PR TITLE
Fix issues with lsp_diagnostic and file_size error on non-files

### DIFF
--- a/autoload/spaceline/diagnostic.vim
+++ b/autoload/spaceline/diagnostic.vim
@@ -61,10 +61,10 @@ endfunction
 
 function! s:diagnostic_nvim_lsp_error()
   if luaeval('#vim.lsp.buf_get_clients(0) ~= 0')
-    if luaeval("vim.lsp.diagnostic.get_count(\"Error\")") == v:null
+    if luaeval("vim.lsp.diagnostic.get_count(0, \"Error\")") == v:null
       return ''
     else
-      return g:spaceline_errorsign. luaeval("vim.lsp.diagnostic.get_count(\"Error\")")
+      return g:spaceline_errorsign. luaeval("vim.lsp.diagnostic.get_count(0, \"Error\")")
     end
   else
     return ''
@@ -73,10 +73,10 @@ endfunction
 
 function! s:diagnostic_nvim_lsp_warn()
   if luaeval('#vim.lsp.buf_get_clients(0) ~= 0')
-    if luaeval("vim.lsp.diagnostic.get_count(\"Warning\")") == v:null
+    if luaeval("vim.lsp.diagnostic.get_count(0, \"Warning\")") == v:null
       return ''
     else
-      return g:spaceline_warnsign. luaeval("vim.lsp.diagnostic.get_count(\"Warning\")")
+      return g:spaceline_warnsign. luaeval("vim.lsp.diagnostic.get_count(0, \"Warning\")")
     end
   else
     return ''

--- a/autoload/spaceline/file.vim
+++ b/autoload/spaceline/file.vim
@@ -34,7 +34,7 @@ function! s:line_percent()
 endfunction
 
 function! spaceline#file#file_size()abort
-  if empty(expand('%:t'))
+  if !filereadable(expand('%:t'))
     return ''
   endif
   let l:oksign = spaceline#diagnostic#diagnostic_ok()


### PR DESCRIPTION
Hi,

This is a great statusline.
When I am using it I have encountered two issues with the statusline.

1. Currently I am using nvim_lsp. The vim.lsp.diagnostic.get_count takes buffer as the first parameter.
2. I got an error opening non-file buffer like "[lua-dev]". So it's better to check if it is file at all.