### PR TITLE
fixing file size calculation by fixing the file path

### DIFF
--- a/autoload/spaceline/file.vim
+++ b/autoload/spaceline/file.vim
@@ -34,7 +34,7 @@ function! s:line_percent()
 endfunction
 
 function! spaceline#file#file_size()abort
-  if !filereadable(expand('%:t'))
+  if !filereadable(expand('%:p'))
     return ''
   endif
   let l:oksign = spaceline#diagnostic#diagnostic_ok()


### PR DESCRIPTION
This PR fixes the issue with file size calculation when user opens a file outside of `pwd`