### PR TITLE
Add option to make spaceline completely empty in inactive windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ let g:spaceline_scroll_chars = ['⎺', '⎻', '⎼', '⎽', '⎯'] " on Linux
 
 ```
 
-- `g:spaceline_empty_inactive` set empty statusline for inactive windows
+- `g:spaceline_empty_inactive` make spaceline completely empty in inactive windows. Default is `0`
 
 # Goyo Support
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ let g:spaceline_scroll_chars = ['⎺', '⎻', '⎼', '⎽', '⎯'] " on Linux
 
 ```
 
+- `g:spaceline_empty_inactive` set empty statusline for inactive windows
+
 # Goyo Support
 
 - check out thinkvim [usage](https://github.com/hardcoreplayers/ThinkVim/blob/master/modules/module-goyo.vim)

--- a/autoload/spaceline.vim
+++ b/autoload/spaceline.vim
@@ -108,16 +108,20 @@ function! s:ActiveStatusLine()
 endfunction
 
 function! s:InActiveStatusLine()
-    let s:statusline=""
-    let s:statusline.="%#HomeMode#"
-    let s:statusline.="%#HomeMode#%{spaceline#buffer#buffer()}"
-    let s:statusline.="%#InActiveHomeRight#"
-    let s:statusline.=g:sep.homemoderight
-    let s:statusline.="%#InActiveFilename#"
-    let s:statusline.="\ "
-    let s:statusline.="%{spaceline#file#file_name()}"
-    let s:statusline.="%="
-    let s:statusline.="%#StatusLineinfo#%{spaceline#file#file_type()}"
+    if g:spaceline_empty_inactive
+      let s:statusline="%="
+    else
+      let s:statusline=""
+      let s:statusline.="%#HomeMode#"
+      let s:statusline.="%#HomeMode#%{spaceline#buffer#buffer()}"
+      let s:statusline.="%#InActiveHomeRight#"
+      let s:statusline.=g:sep.homemoderight
+      let s:statusline.="%#InActiveFilename#"
+      let s:statusline.="\ "
+      let s:statusline.="%{spaceline#file#file_name()}"
+      let s:statusline.="%="
+      let s:statusline.="%#StatusLineinfo#%{spaceline#file#file_type()}"
+    endif
     return s:statusline
 endfunction
 

--- a/plugin/statusline.vim
+++ b/plugin/statusline.vim
@@ -30,6 +30,7 @@ let g:spaceline_branch_icon = get(g:,'spaceline_git_branch_icon','')
 let g:spaceline_diff_icon = get(g:,'spaceline_custom_diff_icon', ['','',''])
 let g:spaceline_funcicon = get(g:,'spaceline_function_icon','')
 
+let g:spaceline_empty_inactive = get(g:,'spaceline_empty_inactive',0)
 
 let g:sep= {}
 let g:sep = spaceline#seperator#spacelineStyle(g:seperate_style)


### PR DESCRIPTION
Helps to identify the active window faster, especially good when windows of different plugins are open, ex: NERDTree, ctrlsf

![alt text](https://i.ibb.co/qkF6tYZ/Screenshot-2021-08-04-at-1-13-41-PM.png)